### PR TITLE
[FEAT] #1 컨텐츠 저장 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/umc/cons/content/controller/ContentController.java
+++ b/src/main/java/com/umc/cons/content/controller/ContentController.java
@@ -1,13 +1,36 @@
 package com.umc.cons.content.controller;
 
+import com.umc.cons.common.config.BaseResponse;
+import com.umc.cons.content.dto.ContentRequestDto;
+import com.umc.cons.content.dto.ContentResponseDto;
+import com.umc.cons.content.dto.MultipleContentRequestDto;
+import com.umc.cons.content.dto.MultipleContentResponseDto;
+import com.umc.cons.content.service.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
+@RequestMapping(value = "/app/contents")
+@RequiredArgsConstructor
 public class ContentController {
-//    @RequestMapping
-//    public String content(Model model){
-////        model.addAttribute("")
+
+    private final ContentService contentService;
+//    @PostMapping("/save")
+//    public BaseResponse<ContentResponseDto> createContents(@RequestBody MultipleContentRequestDto multipleContentRequestDto){
+//
+//        return new BaseResponse<>(contentService.createContents(multipleContentRequestDto));
+//    }
+    @PostMapping("/save")
+    public BaseResponse<MultipleContentResponseDto> createContents(@RequestBody MultipleContentRequestDto multipleContentRequestDto){
+        MultipleContentResponseDto responseDto = contentService.createContents(multipleContentRequestDto);
+        return new BaseResponse<>(responseDto);
+    }
+//    @PutMapping("/save")
+//    public BaseResponse<ContentResponseDto> updateContent(@RequestBody ContentRequestDto contentRequestDto){
+//        return new BaseResponse<>(contentService.createContent(contentRequestDto));
 //    }
 }

--- a/src/main/java/com/umc/cons/content/controller/ContentController.java
+++ b/src/main/java/com/umc/cons/content/controller/ContentController.java
@@ -1,0 +1,13 @@
+package com.umc.cons.content.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class ContentController {
+//    @RequestMapping
+//    public String content(Model model){
+////        model.addAttribute("")
+//    }
+}

--- a/src/main/java/com/umc/cons/content/controller/ContentController.java
+++ b/src/main/java/com/umc/cons/content/controller/ContentController.java
@@ -19,18 +19,15 @@ import org.springframework.web.bind.annotation.*;
 public class ContentController {
 
     private final ContentService contentService;
-//    @PostMapping("/save")
-//    public BaseResponse<ContentResponseDto> createContents(@RequestBody MultipleContentRequestDto multipleContentRequestDto){
-//
-//        return new BaseResponse<>(contentService.createContents(multipleContentRequestDto));
-//    }
-    @PostMapping("/save")
+
+    @PostMapping("")
     public BaseResponse<MultipleContentResponseDto> createContents(@RequestBody MultipleContentRequestDto multipleContentRequestDto){
         MultipleContentResponseDto responseDto = contentService.createContents(multipleContentRequestDto);
         return new BaseResponse<>(responseDto);
     }
-//    @PutMapping("/save")
-//    public BaseResponse<ContentResponseDto> updateContent(@RequestBody ContentRequestDto contentRequestDto){
-//        return new BaseResponse<>(contentService.createContent(contentRequestDto));
-//    }
+    @GetMapping("/{id}")
+    public BaseResponse<ContentResponseDto> getContent(@PathVariable Long id){
+        return new BaseResponse<>(contentService.getContent(id));
+    }
+
 }

--- a/src/main/java/com/umc/cons/content/domain/entity/Content.java
+++ b/src/main/java/com/umc/cons/content/domain/entity/Content.java
@@ -1,0 +1,29 @@
+package com.umc.cons.content.domain.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity @Table(name = "content")
+@Getter@Setter
+public class Content {
+    //TDD: generated value 에 대한 고민 필요
+    @Id
+//    @GeneratedValue
+    @Column(name = "id")
+    private Long id;
+
+    private String name;
+
+    private String image;
+
+    private String genre;
+
+    private LocalDateTime created_at;
+
+    private LocalDateTime modified_at;
+
+
+}

--- a/src/main/java/com/umc/cons/content/domain/entity/Content.java
+++ b/src/main/java/com/umc/cons/content/domain/entity/Content.java
@@ -2,6 +2,7 @@ package com.umc.cons.content.domain.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -9,20 +10,22 @@ import java.time.LocalDateTime;
 @Entity @Table(name = "content")
 @Getter@Setter
 public class Content {
-    //TDD: generated value 에 대한 고민 필요
+    //id 값은 외부 DB값을 사용하므로 생성하지 않음
     @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
-    @Column(name="name")
+    @Column(name="name",nullable = false)
     private String name;
-    @Column(name = "image")
+    @Column(name = "image",nullable = false)
     private String image;
-    @Column(name = "genre")
+    @Column(name = "genre",nullable = false)
     private String genre;
-    @Column(name = "created_at")
+    @Column(name = "is_deleted",nullable = false)
+    @ColumnDefault("false")
+    private boolean is_deleted;
+    @Column(name = "created_at",nullable = false)
     private LocalDateTime created_at;
-    @Column(name = "modified_at")
+    @Column(name = "modified_at",nullable = false)
     private LocalDateTime modified_at;
 
 

--- a/src/main/java/com/umc/cons/content/domain/entity/Content.java
+++ b/src/main/java/com/umc/cons/content/domain/entity/Content.java
@@ -11,18 +11,18 @@ import java.time.LocalDateTime;
 public class Content {
     //TDD: generated value 에 대한 고민 필요
     @Id
-//    @GeneratedValue
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
-
+    @Column(name="name")
     private String name;
-
+    @Column(name = "image")
     private String image;
-
+    @Column(name = "genre")
     private String genre;
-
+    @Column(name = "created_at")
     private LocalDateTime created_at;
-
+    @Column(name = "modified_at")
     private LocalDateTime modified_at;
 
 

--- a/src/main/java/com/umc/cons/content/domain/repository/ContentRepository.java
+++ b/src/main/java/com/umc/cons/content/domain/repository/ContentRepository.java
@@ -1,0 +1,37 @@
+package com.umc.cons.content.domain.repository;
+
+import com.umc.cons.content.domain.entity.Content;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentRepository {
+
+    private final EntityManager em;
+
+    public void save(Content content){
+        em.persist(content);
+    }
+    public Content findOne(Long id){
+        return em.find(Content.class, id);
+    }
+
+    public List<Content> findAll() {
+        return em.createQuery("select m from Content m",Content.class).getResultList();
+    }
+
+    public List<Content> findByName(String name){
+        return em.createQuery("select m from Content m where m.name = :name",Content.class).setParameter("name",name).getResultList();
+    }
+
+
+}

--- a/src/main/java/com/umc/cons/content/domain/repository/ContentRepository.java
+++ b/src/main/java/com/umc/cons/content/domain/repository/ContentRepository.java
@@ -1,6 +1,7 @@
 package com.umc.cons.content.domain.repository;
 
 import com.umc.cons.content.domain.entity.Content;
+import com.umc.cons.content.exception.NotExistContentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/umc/cons/content/dto/ContentRequestDto.java
+++ b/src/main/java/com/umc/cons/content/dto/ContentRequestDto.java
@@ -1,0 +1,2 @@
+package com.umc.cons.content.dto;public class ContentRequestDto {
+}

--- a/src/main/java/com/umc/cons/content/dto/ContentRequestDto.java
+++ b/src/main/java/com/umc/cons/content/dto/ContentRequestDto.java
@@ -1,2 +1,17 @@
-package com.umc.cons.content.dto;public class ContentRequestDto {
+package com.umc.cons.content.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter@Setter
+@NoArgsConstructor
+public class ContentRequestDto {
+    private Long id;
+
+    private String name;
+
+    private String image;
+
+    private String genre;
 }

--- a/src/main/java/com/umc/cons/content/dto/ContentResponseDto.java
+++ b/src/main/java/com/umc/cons/content/dto/ContentResponseDto.java
@@ -1,0 +1,2 @@
+package com.umc.cons.content.dto;public class ContentResponseDto {
+}

--- a/src/main/java/com/umc/cons/content/dto/ContentResponseDto.java
+++ b/src/main/java/com/umc/cons/content/dto/ContentResponseDto.java
@@ -1,2 +1,18 @@
-package com.umc.cons.content.dto;public class ContentResponseDto {
+package com.umc.cons.content.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ContentResponseDto {
+    private Long id;
+
+    private String name;
+
+    private String image;
+
+    private String genre;
 }

--- a/src/main/java/com/umc/cons/content/dto/MultipleContentRequestDto.java
+++ b/src/main/java/com/umc/cons/content/dto/MultipleContentRequestDto.java
@@ -1,0 +1,17 @@
+package com.umc.cons.content.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MultipleContentRequestDto {
+    private List<ContentRequestDto> contents;
+    public MultipleContentRequestDto(List<ContentRequestDto> contents) {
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/umc/cons/content/dto/MultipleContentResponseDto.java
+++ b/src/main/java/com/umc/cons/content/dto/MultipleContentResponseDto.java
@@ -1,0 +1,18 @@
+package com.umc.cons.content.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MultipleContentResponseDto {
+    private List<ContentResponseDto> contents;
+
+    public MultipleContentResponseDto(List<ContentResponseDto> contentResponseDtos) {
+        this.contents = contentResponseDtos;
+    }
+}

--- a/src/main/java/com/umc/cons/content/service/ContentService.java
+++ b/src/main/java/com/umc/cons/content/service/ContentService.java
@@ -1,0 +1,36 @@
+package com.umc.cons.content.service;
+
+import com.umc.cons.content.domain.entity.Content;
+import com.umc.cons.content.domain.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ContentService {
+
+    private final ContentRepository contentRepository;
+
+    //content 저장 로직
+    @Transactional
+    public Long join(Content content){
+        //중복 회원 검증
+        if(validateDuplicateMember(content)){
+            contentRepository.save(content);
+        }
+        return content.getId();
+    }
+
+    private boolean validateDuplicateMember(Content content) {
+        Content findContent = contentRepository.findOne(content.getId());
+        return findContent == null;
+    }
+
+    //특정 content 조회
+    public Content findOne(Long memberId) {
+        return contentRepository.findOne(memberId);
+    }
+}

--- a/src/main/java/com/umc/cons/content/service/ContentService.java
+++ b/src/main/java/com/umc/cons/content/service/ContentService.java
@@ -2,9 +2,19 @@ package com.umc.cons.content.service;
 
 import com.umc.cons.content.domain.entity.Content;
 import com.umc.cons.content.domain.repository.ContentRepository;
+import com.umc.cons.content.dto.ContentRequestDto;
+import com.umc.cons.content.dto.ContentResponseDto;
+import com.umc.cons.content.dto.MultipleContentRequestDto;
+import com.umc.cons.content.dto.MultipleContentResponseDto;
+import com.umc.cons.content.exception.NotExistContentException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Service
@@ -33,4 +43,57 @@ public class ContentService {
     public Content findOne(Long memberId) {
         return contentRepository.findOne(memberId);
     }
+
+    //생성 메서드
+    /**
+     * 콘텐츠 생성
+     */
+    @Transactional
+    public  ContentResponseDto createContent(ContentRequestDto requestDto){
+        //생성
+        Content content = new Content();
+        content.setId(requestDto.getId());content.setName(requestDto.getName());content.setImage(requestDto.getImage());
+        content.setGenre(requestDto.getGenre());
+        content.setCreated_at(LocalDateTime.now());content.setModified_at(LocalDateTime.now());
+        //저장
+        Long savedID = this.join(content);
+        Content savedContent = findOne(savedID);
+        //response
+        ContentResponseDto contentResponseDto = new ContentResponseDto();
+        contentResponseDto.setId(savedContent.getId());
+        contentResponseDto.setName(savedContent.getName());
+        contentResponseDto.setImage(savedContent.getImage());
+        contentResponseDto.setGenre(savedContent.getGenre());
+        return contentResponseDto;
+    }
+    //생성 메서드
+    /**
+     * 콘텐츠 복수개 생성
+     */
+    @Transactional
+    public MultipleContentResponseDto createContents(MultipleContentRequestDto multipleContentRequestDto){
+        List<ContentResponseDto> contentResponseDtos = new ArrayList<>();
+        for(ContentRequestDto contentRequestDto:multipleContentRequestDto.getContents()){
+            contentResponseDtos.add(createContent(contentRequestDto));
+        }
+        return new MultipleContentResponseDto(contentResponseDtos);
+    }
+
+    //수정 메서드
+    /**
+     * 콘텐츠 정보 업데이트
+     */
+    @Transactional
+    public Content updateContent(Long id, String name, String image, String genre){
+        Content content = contentRepository.findOne(id);
+        if (content == null){
+            throw new NotExistContentException("수정할 콘텐츠가 데이터베이스에 존재하지 않습니다.");
+        }
+        content.setName(name);
+        content.setImage(image);
+        content.setGenre(genre);
+        content.setModified_at(LocalDateTime.now());
+        return content;
+    }
+
 }

--- a/src/main/java/com/umc/cons/content/service/ContentService.java
+++ b/src/main/java/com/umc/cons/content/service/ContentService.java
@@ -78,7 +78,22 @@ public class ContentService {
         }
         return new MultipleContentResponseDto(contentResponseDtos);
     }
-
+    //조회 메서드
+    /**
+     * 콘텐츠 정보 조회
+     */
+    public ContentResponseDto getContent(Long id){
+        Content content = contentRepository.findOne(id);
+        if(content ==null){
+            throw new NotExistContentException("조회할 콘텐츠가 데이터베이스에 존재하지 않습니다.");
+        }
+        ContentResponseDto contentResponseDto = new ContentResponseDto();
+        contentResponseDto.setId(content.getId());
+        contentResponseDto.setName(content.getName());
+        contentResponseDto.setImage(content.getImage());
+        contentResponseDto.setGenre(content.getGenre());
+        return contentResponseDto;
+    }
     //수정 메서드
     /**
      * 콘텐츠 정보 업데이트

--- a/src/test/java/com/umc/cons/content/service/ContentServiceTest.java
+++ b/src/test/java/com/umc/cons/content/service/ContentServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.lang.reflect.Member;
+import java.time.LocalDateTime;
 
 import static org.junit.Assert.*;
 
@@ -27,7 +28,11 @@ public class ContentServiceTest {
         //given
         Content content = new Content();
         content.setId(1L);
-
+        content.setName("Example Content 1");
+        content.setImage("example1.jpg");
+        content.setGenre("Action");
+        content.setModified_at(LocalDateTime.now());
+        content.setCreated_at(LocalDateTime.now());
         //when
         Long savedId = contentService.join(content);
 
@@ -41,8 +46,16 @@ public class ContentServiceTest {
         Long duplicatedId = 1L;
         Content content1 = new Content();
         content1.setId(duplicatedId);
+        content1.setName("Example Content 1");
+        content1.setImage("example1.jpg");
+        content1.setGenre("Action");
+        content1.setModified_at(LocalDateTime.now());
+        content1.setCreated_at(LocalDateTime.now());
         Content content2 = new Content();
         content2.setId(duplicatedId);
+        content2.setName("Example Content 2");
+        content2.setImage("example2.jpg");
+        content2.setGenre("Social");
         //when
         contentService.join(content1);
         contentService.join(content2);

--- a/src/test/java/com/umc/cons/content/service/ContentServiceTest.java
+++ b/src/test/java/com/umc/cons/content/service/ContentServiceTest.java
@@ -1,0 +1,55 @@
+package com.umc.cons.content.service;
+
+import com.umc.cons.content.domain.entity.Content;
+import com.umc.cons.content.domain.repository.ContentRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.lang.reflect.Member;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class ContentServiceTest {
+    @Autowired ContentService contentService;
+    @Autowired ContentRepository contentRepository;
+
+    @Test
+    public void 콘텐츠추가() throws Exception{
+        //given
+        Content content = new Content();
+        content.setId(1L);
+
+        //when
+        Long savedId = contentService.join(content);
+
+        //then
+        assertEquals(content, contentRepository.findOne(savedId));
+
+    }
+    @Test
+    public void 중복회원확인() throws Exception{
+        //given
+        Long duplicatedId = 1L;
+        Content content1 = new Content();
+        content1.setId(duplicatedId);
+        Content content2 = new Content();
+        content2.setId(duplicatedId);
+        //when
+        contentService.join(content1);
+        contentService.join(content2);
+
+        //then
+        // content1 만이 저장되어 있어야 함
+        assertEquals(content1,contentRepository.findOne(duplicatedId));
+    }
+
+}


### PR DESCRIPTION
# 관련 이슈
#1 
📋 To Reviewer

컨텐츠 조회 기능을 구현 중 더 이상 필요가 없어져(외부 api이용) 서비스 단계에만 남겨두었습니다. 후에 필요없는게 확정되면 제거 하겠습니다.

❗ 유의사항

✅ 테스트 결과

- 컨텐츠 저장 완료 시
<img width="1481" alt="image" src="https://github.com/UMC-CON/CON-Server/assets/102347351/94ade6e9-6975-4844-bc6d-011dddfbd581">

- 저장된 컨텐츠 조회 
<img width="1486" alt="image" src="https://github.com/UMC-CON/CON-Server/assets/102347351/8e768205-f3a8-47fd-bde8-21cc470657c7">
